### PR TITLE
Geocoding

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -254,6 +254,8 @@
 <script src="dist/app/scripts/components/Request/carpoolIDModel.js"></script>
 <script src="dist/app/scripts/components/Request/RequestController.js"></script>
 <script src="dist/app/scripts/components/Request/responseController.js"></script>
+<script src="dist/app/scripts/components/geocoding/geocodingController.js"></script>
+
 
 <!-- endbower -->
 </body>

--- a/app/scripts/app.ts
+++ b/app/scripts/app.ts
@@ -129,7 +129,9 @@ function($rootScope, Access, $location, $cookies) {
 .factory('ConfigService', function() {
   return {
     host: "http://localhost:",
-    port: "3000"
+    port: "3000",
+    mapsApi : 'https://maps.googleapis.com/maps/api/geocode/json?address=',
+    key : "AIzaSyAjbcANI_Dx4yrB05vl0nBRUniazxWTIV4"
   };
 });
 

--- a/app/scripts/components/geocoding/geocodingController.ts
+++ b/app/scripts/components/geocoding/geocodingController.ts
@@ -1,0 +1,39 @@
+module GeoCoding {
+
+    export interface Scope {
+        geocodeAddress: Function;
+    };
+
+    export interface GeoCode{
+        long: number;
+        lat: number;  
+    }
+    export class Controller {
+        constructor($scope: Scope, $location, $http: any, $cookies: any, ConfigService: any){
+            
+            $scope.geocodeAddress = (address, cb: (success:GeoCode) => void) => {
+                $http.get( ConfigService.mapsApi + address + '&key=' + ConfigService.key)
+                  .success( (data) => {
+                    var Geo:GeoCode = null;
+                    if(data.results[0] !== undefined){
+                        var geo = data.results[0].geometry.location;
+                        Geo = {
+                            long : geo.lng,
+                            lat: geo.lat
+                        };
+                    }
+
+                    cb(Geo);
+                  })
+                  .error((data, status) => {
+                    cb(null);
+                  });
+            }
+        };
+
+    };
+
+};
+app.controllers.controller('GeoCoding.Controller', GeoCoding.Controller);
+
+

--- a/app/scripts/components/geocoding/geocodingController.ts
+++ b/app/scripts/components/geocoding/geocodingController.ts
@@ -14,24 +14,25 @@ module GeoCoding {
             $scope.geocodeAddress = (address, cb: (success:GeoCode) => void) => {
                 $http.get( ConfigService.mapsApi + address + '&key=' + ConfigService.key)
                   .success( (data) => {
+
                     var Geo:GeoCode = null;
                     if(data.results[0] !== undefined){
                         var geo = data.results[0].geometry.location;
                         Geo = {
-                            long : geo.lng,
+                            long: geo.lng,
                             lat: geo.lat
                         };
                     }
-
                     cb(Geo);
+
                   })
                   .error((data, status) => {
                     cb(null);
-                  });
+                  })
             }
-        };
+        }
 
-    };
+    }
 
 };
 app.controllers.controller('GeoCoding.Controller', GeoCoding.Controller);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,9 @@
     ],
     "files": [
         "./app/scripts/app.ts",
+        "./app/scripts/components/Request/RequestController.ts",
+        "./app/scripts/components/Request/carpoolIDModel.ts",
+        "./app/scripts/components/Request/responseController.ts",
         "./app/scripts/components/carpools/carpool.create.ctrl.ts",
         "./app/scripts/components/carpools/carpoolService.ts",
         "./app/scripts/components/carpools/carpoolmodel.ts",
@@ -26,23 +29,14 @@
         "./app/scripts/components/carpools/editCarpoolController.ts",
         "./app/scripts/components/carpools/viewCarpoolsController.ts",
         "./app/scripts/components/dashboard/dashboardController.ts",
-        "./app/scripts/components/carpools/editCarpoolController.ts",
-        "./app/scripts/components/carpools/carpoolmodel.ts",
         "./app/scripts/components/home/homeController.ts",
         "./app/scripts/components/home/usermodel.ts",
         "./app/scripts/components/navbar/navbarController.ts",
         "./app/scripts/components/signup/signupController.ts",
-
-        "./app/scripts/components/Request/carpoolIDModel.ts",
-        "./app/scripts/components/Request/RequestController.ts",
-        "./app/scripts/components/Request/responseController.ts",
-
-
         "./typings/angularjs/angular-route.d.ts",
         "./typings/angularjs/angular.d.ts",
         "./typings/bootstrap/bootstrap.d.ts",
         "./typings/jquery/jquery.d.ts",
         "./typings/tsd.d.ts"
-
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
         "./app/scripts/components/carpools/editCarpoolController.ts",
         "./app/scripts/components/carpools/viewCarpoolsController.ts",
         "./app/scripts/components/dashboard/dashboardController.ts",
+        "./app/scripts/components/geocoding/geocodingController.ts",
         "./app/scripts/components/home/homeController.ts",
         "./app/scripts/components/home/usermodel.ts",
         "./app/scripts/components/navbar/navbarController.ts",


### PR DESCRIPTION
I needed Geocoding for the create a campus section of the admin tool and I know Dom needed it as well, so I split it out into a controller that can be accessed by injecting the $controller functionality into whatever controller you need it in.

To be able to use this you need to:
- Update your controller constructor so that it takes a `$controller:any` argument
- Add `$new:function` to your Scope interface in the controller

Once you have done that you can access the functionality by doing something like:

```
var address = "1234 fake st";
var geoCode = $scope.$new();
$controller('GeoCoding.Controller',{$scope : geoCode });
geoCode.geocodeAddress(address, (geo) => {
  console.log(geo);
});
```

And then replace the `console.log(geo)` with whatever you have to do with the geolocation coordinates.  I made sure that the coordinates it returns matches what the backend is expecting.  Also, this way when they change the backend to use geometric pairs we will only have to update the calls in one place.

This is currently using a google maps api key that is assigned to my personal google account.  I regenerated a new one so the one in the repo will expire in 24 hours.  I will post the new one in the slack frontend section, you will need to change the ConfigService.key object in app.ts to the new key, please do not commit the new key, I really don't want someone to scrape it from the repo.
